### PR TITLE
Revisions on several issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Please see our [documentation](https://opendistro.github.io/for-elasticsearch-do
   - Windows System
     1. Find **My Computers** from file directory, right click and select **properties**.
     1. Select the **Advanced** tab, select **Environment variables**.
-    1. Edit **JAVA_HOME** to path of where JDK softeare is installed.
+    1. Edit **JAVA_HOME** to path of where JDK software is installed.
 
 
 ## Build

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/MonitorRunnerIT.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/MonitorRunnerIT.kt
@@ -591,8 +591,8 @@ class MonitorRunnerIT : AlertingRestTestCase() {
                 path = "_cat/indices",
                 params = mapOf(),
                 url = "",
-                connection_timeout = 5000,
-                socket_timeout = 5000)
+                connection_timeout = 5,
+                socket_timeout = 5)
         val monitor = createMonitor(randomMonitor(inputs = listOf(input)))
         val response = executeMonitor(monitor.id)
         val output = entityAsMap(response)
@@ -614,8 +614,8 @@ class MonitorRunnerIT : AlertingRestTestCase() {
                 path = "_cluster/health",
                 params = mapOf(),
                 url = "",
-                connection_timeout = 5000,
-                socket_timeout = 5000)
+                connection_timeout = 5,
+                socket_timeout = 5)
         val monitor = createMonitor(randomMonitor(inputs = listOf(input)))
         val response = executeMonitor(monitor.id)
 
@@ -646,8 +646,8 @@ class MonitorRunnerIT : AlertingRestTestCase() {
                 path = "_cluster/health",
                 params = mapOf(),
                 url = "",
-                connection_timeout = 5000,
-                socket_timeout = 5000)
+                connection_timeout = 5,
+                socket_timeout = 5)
         val monitor = createMonitor(randomMonitor(inputs = listOf(input), triggers = listOf(trigger)))
         val response = executeMonitor(monitor.id)
 
@@ -675,8 +675,8 @@ class MonitorRunnerIT : AlertingRestTestCase() {
                 path = "_cluster/health",
                 params = mapOf(),
                 url = "",
-                connection_timeout = 5000,
-                socket_timeout = 5000)
+                connection_timeout = 5,
+                socket_timeout = 5)
         val monitor = createMonitor(randomMonitor(inputs = listOf(input), triggers = listOf(trigger)))
         val response = executeMonitor(monitor.id)
 

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/TestHelpers.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/TestHelpers.kt
@@ -74,8 +74,8 @@ fun randomHttpInput(
     path: String = ESRestTestCase.randomAlphaOfLength(10),
     params: Map<String, String> = mapOf(),
     url: String = "",
-    connection_timeout: Int = randomInt(10000),
-    socket_timeout: Int = randomInt(10000)
+    connection_timeout: Int = randomInt(10),
+    socket_timeout: Int = randomInt(10)
 ): HttpInput {
     return HttpInput(
         scheme = scheme,

--- a/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/httpapi/HttpExtensions.kt
+++ b/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/httpapi/HttpExtensions.kt
@@ -41,9 +41,10 @@ fun HttpResponse.toMap(): Map<String, Any> {
 }
 
 fun HttpInput.toGetRequest(): HttpGet {
+    // Change timeout values to settings specified from input, multiply by 1000 to convert to milliseconds.
     val requestConfig = RequestConfig.custom()
-            .setConnectTimeout(this.connection_timeout)
-            .setSocketTimeout(this.socket_timeout)
+            .setConnectTimeout(this.connection_timeout * 1000)
+            .setSocketTimeout(this.socket_timeout * 1000)
             .build()
     // If url field is null or empty, construct an url field by field.
     val constructedUrl = if (Strings.isNullOrEmpty(this.url)) {

--- a/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/httpapi/HttpExtensions.kt
+++ b/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/httpapi/HttpExtensions.kt
@@ -21,7 +21,7 @@ suspend fun <C : HttpAsyncClient, T> C.suspendUntil(block: C.(FutureCallback<T>)
         suspendCancellableCoroutine { cont ->
             block(object : FutureCallback<T> {
                 override fun cancelled() {
-                    cont.resumeWith(Result.failure(CancellationException("Request cancelled")))
+                    cont.resumeWithException(CancellationException("Request cancelled"))
                 }
 
                 override fun completed(result: T) {

--- a/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/model/HttpInput.kt
+++ b/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/model/HttpInput.kt
@@ -150,7 +150,7 @@ data class HttpInput(
     }
 
     /**
-     * Helper function to check whether only url field is defined or when other fields are defined, url field is not.
+     * Helper function to check whether one of url or scheme+host+port+path+params is defined.
      */
     private fun validateFields(): Boolean {
         if (url.isNotEmpty()) {

--- a/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/model/HttpInput.kt
+++ b/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/model/HttpInput.kt
@@ -47,11 +47,11 @@ data class HttpInput(
         require(validateFields()) {
             "Either one of url or scheme + host + port+ + path + params can be set."
         }
-        require(connection_timeout > 0) {
-            "Connection timeout: $connection_timeout is not greater than 0."
+        require(connection_timeout in 1..60) {
+            "Connection timeout: $connection_timeout is not in the range of 1 - 60"
         }
-        require(socket_timeout > 0) {
-            "Socket timeout: $socket_timeout is not greater than 0."
+        require(socket_timeout in 1..60) {
+            "Socket timeout: $socket_timeout is not in the range of 1 - 60"
         }
 
         // Create an UrlValidator that only accepts "http" and "https" as valid scheme and allows local URLs.

--- a/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/model/HttpInput.kt
+++ b/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/model/HttpInput.kt
@@ -44,6 +44,10 @@ data class HttpInput(
 
     // Verify parameters are valid during creation
     init {
+        require(validateFields()) {
+            "Invalid fields, if url is set, scheme, host, port, and params should not be set.\n" +
+                    "If either scheme, host, port, or params is set, url should be empty."
+        }
         require(connection_timeout > 0) {
             "Connection timeout: $connection_timeout is not greater than 0."
         }
@@ -137,5 +141,15 @@ data class HttpInput(
             }
             return HttpInput(scheme, host, port, path, params, url, connectionTimeout, socketTimeout)
         }
+    }
+
+    /**
+     * Helper function to check whether only url field is defined or when other fields are defined, url field is not.
+     */
+    private fun validateFields(): Boolean {
+        if (url.isNotEmpty()) {
+            return (Strings.isEmpty(scheme) && Strings.isNullOrEmpty(host) && (port == -1) && params.isEmpty())
+        }
+        return true
     }
 }

--- a/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/model/HttpInput.kt
+++ b/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/model/HttpInput.kt
@@ -55,7 +55,7 @@ data class HttpInput(
         val urlValidator = UrlValidator(arrayOf("http", "https"), UrlValidator.ALLOW_LOCAL_URLS)
 
         // Build url field by field if not provided as whole, and update url field.
-        val constructedUrl = if (Strings.isNullOrEmpty(url)) {
+        val constructedUrl = if (Strings.isEmpty(url)) {
             val uriBuilder = URIBuilder()
             uriBuilder.scheme = scheme
             uriBuilder.host = host

--- a/core/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/model/HttpInputTest.kt
+++ b/core/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/model/HttpInputTest.kt
@@ -15,8 +15,10 @@
 
 package com.amazon.opendistroforelasticsearch.alerting.core.model
 
+import java.net.URISyntaxException
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlin.test.fail
 
 class HttpInputTest {
@@ -48,8 +50,8 @@ class HttpInputTest {
             // Invalid url
             HttpInput("", "", -1, "", mapOf(), "¯¯\\_( ͡° ͜ʖ ͡°)_//¯ ", 5000, 5000)
             fail("Invalid url when creating HttpInput should fail.")
-        } catch (e: IllegalArgumentException) {
-            assertEquals("Invalid url: ¯¯\\_( ͡° ͜ʖ ͡°)_//¯ ", e.message)
+        } catch (e: URISyntaxException) {
+            assertTrue(e.message.toString().contains("Illegal character in path at index"), "Error message is : ${e.message}")
         }
         try {
             // Invalid connection timeout
@@ -70,8 +72,13 @@ class HttpInputTest {
             HttpInput("http", "localhost", 9200, "_cluster/health", mapOf(), "http://localhost:9200/_cluster/health", 5000, 5000)
             fail("Setting url and other fields at the same time should fail.")
         } catch (e: IllegalArgumentException) {
-            assertEquals("Invalid fields, if url is set, scheme, host, port, and params should not be set.\n" +
-                    "If either scheme, host, port, or params is set, url should be empty.", e.message)
+            assertEquals("Either one of url or scheme + host + port+ + path + params can be set.", e.message)
+        }
+        try {
+            HttpInput("http", "localhost", 30678, "_cluster/health", mapOf(), "", 5000, 5000)
+            fail("localhost with invalid port number should fail.")
+        } catch(e: IllegalArgumentException) {
+            assertEquals("Host: localhost is restricted to port 9200.", e.message)
         }
     }
 

--- a/core/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/model/HttpInputTest.kt
+++ b/core/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/model/HttpInputTest.kt
@@ -15,7 +15,6 @@
 
 package com.amazon.opendistroforelasticsearch.alerting.core.model
 
-import org.junit.Assert
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.fail
@@ -29,42 +28,50 @@ class HttpInputTest {
             HttpInput("notAValidScheme", "localhost", 9200, "_cluster/health", mapOf(), "", 5000, 5000)
             fail("Invalid scheme when creating HttpInput should fail.")
         } catch (e: IllegalArgumentException) {
-            Assert.assertEquals("Invalid url: notAValidScheme://localhost:9200/_cluster/health", e.message)
+            assertEquals("Invalid url: notAValidScheme://localhost:9200/_cluster/health", e.message)
         }
         try {
             // Invalid host
             HttpInput("http", "loco//host", 9200, "_cluster/health", mapOf(), "", 5000, 5000)
             fail("Invalid host when creating HttpInput should fail.")
         } catch (e: IllegalArgumentException) {
-            Assert.assertEquals("Invalid url: http://loco//host:9200/_cluster/health", e.message)
+            assertEquals("Invalid url: http://loco//host:9200/_cluster/health", e.message)
         }
         try {
             // Invalid path
             HttpInput("http", "localhost", 9200, "///", mapOf(), "", 5000, 5000)
             fail("Invalid path when creating HttpInput should fail.")
         } catch (e: IllegalArgumentException) {
-            Assert.assertEquals("Invalid url: http://localhost:9200///", e.message)
+            assertEquals("Invalid url: http://localhost:9200///", e.message)
         }
         try {
             // Invalid url
-            HttpInput("http", "localhost", 9200, "_cluster/health", mapOf(), "¯¯\\_( ͡° ͜ʖ ͡°)_//¯ ", 5000, 5000)
+            HttpInput("", "", -1, "", mapOf(), "¯¯\\_( ͡° ͜ʖ ͡°)_//¯ ", 5000, 5000)
             fail("Invalid url when creating HttpInput should fail.")
         } catch (e: IllegalArgumentException) {
-            Assert.assertEquals("Invalid url: ¯¯\\_( ͡° ͜ʖ ͡°)_//¯ ", e.message)
+            assertEquals("Invalid url: ¯¯\\_( ͡° ͜ʖ ͡°)_//¯ ", e.message)
         }
         try {
             // Invalid connection timeout
             HttpInput("http", "localhost", 9200, "_cluster/health", mapOf(), "", -5000, 5000)
             fail("Invalid connection timeout when creating HttpInput should fail.")
         } catch (e: IllegalArgumentException) {
-            Assert.assertEquals("Connection timeout: -5000 is not greater than 0.", e.message)
+            assertEquals("Connection timeout: -5000 is not greater than 0.", e.message)
         }
         try {
             // Invalid socket timeout
             HttpInput("http", "localhost", 9200, "_cluster/health", mapOf(), "", 5000, -5000)
             fail("Invalid socket timeout when creating HttpInput should fail.")
         } catch (e: IllegalArgumentException) {
-            Assert.assertEquals("Socket timeout: -5000 is not greater than 0.", e.message)
+            assertEquals("Socket timeout: -5000 is not greater than 0.", e.message)
+        }
+        try {
+            // Setting other fields along with url field is not allowed
+            HttpInput("http", "localhost", 9200, "_cluster/health", mapOf(), "http://localhost:9200/_cluster/health", 5000, 5000)
+            fail("Setting url and other fields at the same time should fail.")
+        } catch (e: IllegalArgumentException) {
+            assertEquals("Invalid fields, if url is set, scheme, host, port, and params should not be set.\n" +
+                    "If either scheme, host, port, or params is set, url should be empty.", e.message)
         }
     }
 
@@ -93,6 +100,7 @@ class HttpInputTest {
         assertEquals(validHttpInput.port, 9200)
         assertEquals(validHttpInput.path, "_cluster/health")
         assertEquals(validHttpInput.params, mapOf("value" to "x", "secondVal" to "second"))
+        assertEquals(validHttpInput.url, "")
         assertEquals(validHttpInput.connection_timeout, 5000)
         assertEquals(validHttpInput.socket_timeout, 2500)
     }

--- a/core/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/model/HttpInputTest.kt
+++ b/core/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/model/HttpInputTest.kt
@@ -27,57 +27,57 @@ class HttpInputTest {
     fun `test invalid urls`() {
         try {
             // Invalid scheme
-            HttpInput("notAValidScheme", "localhost", 9200, "_cluster/health", mapOf(), "", 5000, 5000)
+            HttpInput("notAValidScheme", "localhost", 9200, "_cluster/health", mapOf(), "", 5, 5)
             fail("Invalid scheme when creating HttpInput should fail.")
         } catch (e: IllegalArgumentException) {
             assertEquals("Invalid url: notAValidScheme://localhost:9200/_cluster/health", e.message)
         }
         try {
             // Invalid host
-            HttpInput("http", "loco//host", 9200, "_cluster/health", mapOf(), "", 5000, 5000)
+            HttpInput("http", "loco//host", 9200, "_cluster/health", mapOf(), "", 5, 5)
             fail("Invalid host when creating HttpInput should fail.")
         } catch (e: IllegalArgumentException) {
             assertEquals("Invalid url: http://loco//host:9200/_cluster/health", e.message)
         }
         try {
             // Invalid path
-            HttpInput("http", "localhost", 9200, "///", mapOf(), "", 5000, 5000)
+            HttpInput("http", "localhost", 9200, "///", mapOf(), "", 5, 5)
             fail("Invalid path when creating HttpInput should fail.")
         } catch (e: IllegalArgumentException) {
             assertEquals("Invalid url: http://localhost:9200///", e.message)
         }
         try {
             // Invalid url
-            HttpInput("", "", -1, "", mapOf(), "¯¯\\_( ͡° ͜ʖ ͡°)_//¯ ", 5000, 5000)
+            HttpInput("", "", -1, "", mapOf(), "¯¯\\_( ͡° ͜ʖ ͡°)_//¯ ", 5, 5)
             fail("Invalid url when creating HttpInput should fail.")
         } catch (e: URISyntaxException) {
             assertTrue(e.message.toString().contains("Illegal character in path at index"), "Error message is : ${e.message}")
         }
         try {
             // Invalid connection timeout
-            HttpInput("http", "localhost", 9200, "_cluster/health", mapOf(), "", -5000, 5000)
+            HttpInput("http", "localhost", 9200, "_cluster/health", mapOf(), "", 70, 5)
             fail("Invalid connection timeout when creating HttpInput should fail.")
         } catch (e: IllegalArgumentException) {
-            assertEquals("Connection timeout: -5000 is not greater than 0.", e.message)
+            assertEquals("Connection timeout: 70 is not in the range of 1 - 60", e.message)
         }
         try {
             // Invalid socket timeout
-            HttpInput("http", "localhost", 9200, "_cluster/health", mapOf(), "", 5000, -5000)
+            HttpInput("http", "localhost", 9200, "_cluster/health", mapOf(), "", 5, -5)
             fail("Invalid socket timeout when creating HttpInput should fail.")
         } catch (e: IllegalArgumentException) {
-            assertEquals("Socket timeout: -5000 is not greater than 0.", e.message)
+            assertEquals("Socket timeout: -5 is not in the range of 1 - 60", e.message)
         }
         try {
             // Setting other fields along with url field is not allowed
-            HttpInput("http", "localhost", 9200, "_cluster/health", mapOf(), "http://localhost:9200/_cluster/health", 5000, 5000)
+            HttpInput("http", "localhost", 9200, "_cluster/health", mapOf(), "http://localhost:9200/_cluster/health", 5, 5)
             fail("Setting url and other fields at the same time should fail.")
         } catch (e: IllegalArgumentException) {
             assertEquals("Either one of url or scheme + host + port+ + path + params can be set.", e.message)
         }
         try {
-            HttpInput("http", "localhost", 30678, "_cluster/health", mapOf(), "", 5000, 5000)
+            HttpInput("http", "localhost", 30678, "_cluster/health", mapOf(), "", 5, 5)
             fail("localhost with invalid port number should fail.")
-        } catch(e: IllegalArgumentException) {
+        } catch (e: IllegalArgumentException) {
             assertEquals("Host: localhost is restricted to port 9200.", e.message)
         }
     }
@@ -85,10 +85,10 @@ class HttpInputTest {
     // Test valid url with complete url
     @Test
     fun `test valid HttpInput using url`() {
-        val validHttpInput = HttpInput("", "", -1, "", mapOf(), "http://localhost:9200/_cluster/health/", 5000, 5000)
+        val validHttpInput = HttpInput("", "", -1, "", mapOf(), "http://localhost:9200/_cluster/health/", 5, 5)
         assertEquals(validHttpInput.url, "http://localhost:9200/_cluster/health/")
-        assertEquals(validHttpInput.connection_timeout, 5000)
-        assertEquals(validHttpInput.socket_timeout, 5000)
+        assertEquals(validHttpInput.connection_timeout, 5)
+        assertEquals(validHttpInput.socket_timeout, 5)
     }
 
     @Test
@@ -100,15 +100,15 @@ class HttpInputTest {
                 path = "_cluster/health",
                 params = mapOf("value" to "x", "secondVal" to "second"),
                 url = "",
-                connection_timeout = 5000,
-                socket_timeout = 2500)
+                connection_timeout = 5,
+                socket_timeout = 10)
         assertEquals(validHttpInput.scheme, "http")
         assertEquals(validHttpInput.host, "localhost")
         assertEquals(validHttpInput.port, 9200)
         assertEquals(validHttpInput.path, "_cluster/health")
         assertEquals(validHttpInput.params, mapOf("value" to "x", "secondVal" to "second"))
         assertEquals(validHttpInput.url, "")
-        assertEquals(validHttpInput.connection_timeout, 5000)
-        assertEquals(validHttpInput.socket_timeout, 2500)
+        assertEquals(validHttpInput.connection_timeout, 5)
+        assertEquals(validHttpInput.socket_timeout, 10)
     }
 }


### PR DESCRIPTION
- Reusing client in `MonitorRunner`
- Allowing only port 9200 for localhost in `HttpInput`
- Fixed typo in `README.md`
- Validation only one of url or scheme+host+port+path+params is set in `HttpInput`.
- Set maximum timeout values to 60s and updated tests.